### PR TITLE
Add support for HTTP(S) proxy w/ CONNECT method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,13 +16,13 @@ endif
 default: build
 
 build: clean
-	go build -ldflags "-X github.com/ameshkov/sniproxy/internal/cmd.VersionString=$(VERSION)"
+	go build -ldflags "-X github.com/ameshkov/sniproxy/internal/version.VersionString=$(VERSION)"
 
 release: check-env-release
 	mkdir -p $(BUILDDIR)
 	cp LICENSE $(BUILDDIR)/
 	cp README.md $(BUILDDIR)/
-	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X github.com/ameshkov/sniproxy/internal/cmd.VersionString=$(VERSION)" -o $(BUILDDIR)/$(NAME)$(ext)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build -ldflags "-X github.com/ameshkov/sniproxy/internal/version.VersionString=$(VERSION)" -o $(BUILDDIR)/$(NAME)$(ext)
 	cd $(BASE_BUILDDIR) ; $(archiveCmd)
 
 test:

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Application Options:
       --http-port=            Port the SNI proxy server will be listening for plain HTTP connections. (default: 80)
       --tls-address=          IP address the SNI proxy server will be listening for TLS connections. (default: 0.0.0.0)
       --tls-port=             Port the SNI proxy server will be listening for TLS connections. (default: 443)
-      --forward-proxy=        Address of a SOCKS proxy that the connections will be forwarded to according to forward-rule.
+      --forward-proxy=        Address of a SOCKS/HTTP/HTTPS proxy that the connections will be forwarded to according to forward-rule.
       --forward-rule=         Wildcard that defines what connections will be forwarded to forward-proxy. Can be specified multiple
                               times. If no rules are specified, all connections will be forwarded to the proxy.
       --block-rule=           Wildcard that defines what domains should be blocked. Can be specified multiple times.

--- a/internal/cmd/cmd.go
+++ b/internal/cmd/cmd.go
@@ -10,18 +10,15 @@ import (
 	"github.com/AdguardTeam/golibs/log"
 	"github.com/ameshkov/sniproxy/internal/dnsproxy"
 	"github.com/ameshkov/sniproxy/internal/sniproxy"
+	"github.com/ameshkov/sniproxy/internal/version"
 	goFlags "github.com/jessevdk/go-flags"
 )
-
-// VersionString is the version that we'll print to the output. See the makefile
-// for more details.
-var VersionString = "undefined"
 
 // Main is the entry point of the program.Ï
 func Main() {
 	for _, arg := range os.Args {
 		if arg == "--version" {
-			fmt.Printf("sniproxy version: %s\n", VersionString)
+			fmt.Printf("sniproxy version: %s\n", version.VersionString)
 			os.Exit(0)
 		}
 	}

--- a/internal/cmd/options.go
+++ b/internal/cmd/options.go
@@ -45,9 +45,9 @@ type Options struct {
 	// TLSPort is the port the SNI proxy server will be listening to.
 	TLSPort int `long:"tls-port" description:"Port the SNI proxy server will be listening for TLS connections." default:"443"`
 
-	// ForwardProxy is the address of a SOCKS proxy that the connections will
+	// ForwardProxy is the address of a SOCKS/HTTP/HTTPS proxy that the connections will
 	// be forwarded to according to ForwardRules.
-	ForwardProxy string `long:"forward-proxy" description:"Address of a SOCKS proxy that the connections will be forwarded to according to forward-rule."`
+	ForwardProxy string `long:"forward-proxy" description:"Address of a SOCKS/HTTP/HTTPS proxy that the connections will be forwarded to according to forward-rule."`
 
 	// ForwardRules is a list of wildcards that define what connections will be
 	// forwarded to ForwardProxy.  If the list is empty and ForwardProxy is set,

--- a/internal/httpupstream/upstream.go
+++ b/internal/httpupstream/upstream.go
@@ -103,7 +103,7 @@ func (d *HTTPProxyDialer) DialContext(ctx context.Context, network, address stri
 		case <-stopGuardEvent:
 			close(guardErr)
 		case <-ctx.Done():
-			conn.Close()
+			_ = conn.Close()
 			guardErr <- ctx.Err()
 		}
 	}()
@@ -123,13 +123,13 @@ func (d *HTTPProxyDialer) DialContext(ctx context.Context, network, address stri
 	fmt.Fprintf(&reqBuf, "User-Agent: sniproxy/%s\r\n\r\n", version.VersionString)
 	_, err = io.Copy(conn, &reqBuf)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("unable to write proxy request for remote connection: %w", err)
 	}
 
 	resp, err := readResponse(conn)
 	if err != nil {
-		conn.Close()
+		_ = conn.Close()
 		return nil, fmt.Errorf("reading proxy response failed: %w", err)
 	}
 

--- a/internal/httpupstream/upstream.go
+++ b/internal/httpupstream/upstream.go
@@ -1,0 +1,216 @@
+package httpupstream
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+
+	xproxy "golang.org/x/net/proxy"
+
+	"github.com/ameshkov/sniproxy/internal/version"
+)
+
+type Dialer xproxy.Dialer
+type ContextDialer xproxy.ContextDialer
+
+type HTTPProxyDialer struct {
+	address  string
+	tls      bool
+	userinfo *url.Userinfo
+	next     ContextDialer
+}
+
+func init() {
+	register()
+}
+
+func register() {
+	xproxy.RegisterDialerType("http", HTTPProxyDialerFromURL)
+	xproxy.RegisterDialerType("https", HTTPProxyDialerFromURL)
+}
+
+func NewHTTPProxyDialer(address string, tls bool, userinfo *url.Userinfo, next Dialer) *HTTPProxyDialer {
+	return &HTTPProxyDialer{
+		address:  address,
+		tls:      tls,
+		next:     maybeWrapWithContextDialer(next),
+		userinfo: userinfo,
+	}
+}
+
+func HTTPProxyDialerFromURL(u *url.URL, next xproxy.Dialer) (xproxy.Dialer, error) {
+	host := u.Hostname()
+	port := u.Port()
+	tls := false
+
+	switch strings.ToLower(u.Scheme) {
+	case "http":
+		if port == "" {
+			port = "80"
+		}
+	case "https":
+		tls = true
+		if port == "" {
+			port = "443"
+		}
+	default:
+		return nil, errors.New("unsupported proxy type")
+	}
+
+	address := net.JoinHostPort(host, port)
+
+	return NewHTTPProxyDialer(address, tls, u.User, next), nil
+}
+
+func (d *HTTPProxyDialer) Dial(network, address string) (net.Conn, error) {
+	return d.DialContext(context.Background(), network, address)
+}
+
+func (d *HTTPProxyDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	switch network {
+	case "tcp", "tcp4", "tcp6":
+	default:
+		return nil, errors.New("only \"tcp\" network is supported")
+	}
+	conn, err := d.next.DialContext(ctx, "tcp", d.address)
+	if err != nil {
+		return nil, fmt.Errorf("proxy dialer is unable to make connection: %w", err)
+	}
+	if d.tls {
+		hostname, _, err := net.SplitHostPort(d.address)
+		if err != nil {
+			hostname = address
+		}
+		conn = tls.Client(conn, &tls.Config{
+			ServerName: hostname,
+		})
+	}
+
+	stopGuardEvent := make(chan struct{})
+	guardErr := make(chan error, 1)
+	go func() {
+		select {
+		case <-stopGuardEvent:
+			close(guardErr)
+		case <-ctx.Done():
+			conn.Close()
+			guardErr <- ctx.Err()
+		}
+	}()
+	var stopGuardOnce sync.Once
+	stopGuard := func() {
+		stopGuardOnce.Do(func() {
+			close(stopGuardEvent)
+		})
+	}
+	defer stopGuard()
+
+	var reqBuf bytes.Buffer
+	fmt.Fprintf(&reqBuf, "CONNECT %s HTTP/1.1\r\nHost: %s\r\n", address, address)
+	if d.userinfo != nil {
+		fmt.Fprintf(&reqBuf, "Proxy-Authorization: %s\r\n", basicAuthHeader(d.userinfo))
+	}
+	fmt.Fprintf(&reqBuf, "User-Agent: sniproxy/%s\r\n\r\n", version.VersionString)
+	_, err = io.Copy(conn, &reqBuf)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("unable to write proxy request for remote connection: %w", err)
+	}
+
+	resp, err := readResponse(conn)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("reading proxy response failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		conn.Close()
+		return nil, fmt.Errorf("bad status code from proxy: %d", resp.StatusCode)
+	}
+
+	stopGuard()
+	if err := <-guardErr; err != nil {
+		return nil, fmt.Errorf("context error: %w", err)
+	}
+	return conn, nil
+}
+
+var (
+	responseTerminator = []byte("\r\n\r\n")
+)
+
+func readResponse(r io.Reader) (*http.Response, error) {
+	var respBuf bytes.Buffer
+	b := make([]byte, 1)
+	for !bytes.HasSuffix(respBuf.Bytes(), responseTerminator) {
+		n, err := r.Read(b)
+		if err != nil {
+			return nil, fmt.Errorf("unable to read HTTP response: %w", err)
+		}
+		if n == 0 {
+			continue
+		}
+		_, err = respBuf.Write(b)
+		if err != nil {
+			return nil, fmt.Errorf("unable to store byte into buffer: %w", err)
+		}
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(&respBuf), nil)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decode proxy response: %w", err)
+	}
+	return resp, nil
+}
+
+func basicAuthHeader(userinfo *url.Userinfo) string {
+	username := userinfo.Username()
+	password, _ := userinfo.Password()
+	return "Basic " + base64.StdEncoding.EncodeToString(
+		[]byte(username+":"+password))
+}
+
+type wrappedDialer struct {
+	d Dialer
+}
+
+func (wd wrappedDialer) Dial(net, address string) (net.Conn, error) {
+	return wd.d.Dial(net, address)
+}
+
+func (wd wrappedDialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
+	var (
+		conn net.Conn
+		done = make(chan struct{}, 1)
+		err  error
+	)
+	go func() {
+		conn, err = wd.d.Dial(network, address)
+		close(done)
+		if conn != nil && ctx.Err() != nil {
+			conn.Close()
+		}
+	}()
+	select {
+	case <-ctx.Done():
+		err = ctx.Err()
+	case <-done:
+	}
+	return conn, err
+}
+
+func maybeWrapWithContextDialer(d Dialer) ContextDialer {
+	if xd, ok := d.(ContextDialer); ok {
+		return xd
+	}
+	return wrappedDialer{d}
+}

--- a/internal/sniproxy/sniproxy.go
+++ b/internal/sniproxy/sniproxy.go
@@ -266,11 +266,20 @@ func (p *SNIProxy) shouldForward(ctx *SNIContext) (ok bool) {
 	return false
 }
 
+type writeCloser interface {
+	CloseWrite() error
+}
+
 // copy copies data from src to dst and signals that the work is done via the
 // wg wait group.
 func tunnel(ctx *SNIContext, dst net.Conn, src io.Reader) (written int64) {
 	defer func() {
-		_ = dst.(*net.TCPConn).CloseWrite()
+		switch c := dst.(type) {
+		case writeCloser:
+			_ = c.CloseWrite()
+		default:
+			_ = c.Close()
+		}
 	}()
 
 	written, err := io.Copy(dst, src)

--- a/internal/sniproxy/sniproxy.go
+++ b/internal/sniproxy/sniproxy.go
@@ -22,6 +22,8 @@ import (
 	"github.com/AdguardTeam/golibs/netutil"
 	"github.com/IGLOU-EU/go-wildcard"
 	"golang.org/x/net/proxy"
+
+	_ "github.com/ameshkov/sniproxy/internal/httpupstream"
 )
 
 const (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,5 @@
+package version
+
+// VersionString is the version that we'll print to the output. See the makefile
+// for more details.
+var VersionString = "undefined"


### PR DESCRIPTION
This set of changes introduces support for HTTP(S) proxies supporting CONNECT method. Also optional basic authentication is supported. Example:

```
sniproxy --dns-redirect-ipv4-to=1.1.1.1 --forward-proxy='https://admin:XXXXXXXX@example.org'
```